### PR TITLE
feat: only throw error when subscribed to task instance as promise

### DIFF
--- a/src/__tests__/handing-errors.tsx
+++ b/src/__tests__/handing-errors.tsx
@@ -117,19 +117,7 @@ test("it does not report an errored task as the last successful task", async () 
       state = taskState;
     });
 
-    return (
-      <button
-        onClick={async () => {
-          try {
-            await doIt();
-          } catch (e) {
-            // Swallow error
-          }
-        }}
-      >
-        Perform Work
-      </button>
-    );
+    return <button onClick={() => doIt()}>Perform Work</button>;
   }
 
   const { getByText } = render(<ErrorInWork />);

--- a/src/__tests__/keep/all.tsx
+++ b/src/__tests__/keep/all.tsx
@@ -70,6 +70,7 @@ test("does not cancel existing runs when one completes", async () => {
     fireEvent.click(getByTestId("perform"));
   });
 
+  await wait();
   first = false;
 
   act(() => {

--- a/src/deferred.ts
+++ b/src/deferred.ts
@@ -1,4 +1,6 @@
 export default class Deferred<T> implements Promise<T> {
+  protected subscribed = false;
+
   private promise: Promise<T>;
   private _resolve!: (result: T) => void;
   private _reject!: (reason: any) => void;
@@ -30,6 +32,8 @@ export default class Deferred<T> implements Promise<T> {
       | undefined
       | null
   ): Promise<TResult1 | TResult2> {
+    this.subscribed = true;
+
     return this.promise.then(onfulfilled, onrejected);
   }
 
@@ -39,10 +43,14 @@ export default class Deferred<T> implements Promise<T> {
       | undefined
       | null
   ) {
+    this.subscribed = true;
+
     return this.promise.catch(onrejected);
   }
 
   finally(onfinally?: (() => void) | undefined | null) {
+    this.subscribed = true;
+
     return this.promise.finally(onfinally);
   }
 }


### PR DESCRIPTION
Now, performing a task will only throw an error if the resulting promise has been subscribed to (meaning the promise is being monitored with `.then` or `.catch`, or it was used with `async`/`await`).

This allows you to perform a task and handle the error declaritively, using the `.error` property on the `TaskInstance` where it makes sense, but still handle it imperitively using a more traditional approach if desired.