### PR TITLE
refactor: move task state to `current` property

### DIFF
--- a/docs/components/ConcurrencyDemo.tsx
+++ b/docs/components/ConcurrencyDemo.tsx
@@ -70,7 +70,7 @@ const ConcurrencyDemo = ({ title, keep, ...rest }) => {
         <Task key={index}>
           <ProgressBar color="red" completion={progressBar.completion} />
           <TextButton
-            disabled={!progressBar.task.isRunning}
+            disabled={!progressBar.task.current.isRunning}
             onClick={() => {
               progressBar.task.cancel();
             }}

--- a/src/__tests__/all-task-state.tsx
+++ b/src/__tests__/all-task-state.tsx
@@ -32,14 +32,14 @@ test("allows cancelling all task instances", async () => {
     second = perform(result);
   });
 
-  expect(first.isCancelled).toBe(false);
-  expect(second.isCancelled).toBe(false);
+  expect(first.current.isCancelled).toBe(false);
+  expect(second.current.isCancelled).toBe(false);
 
   stateFor(result).cancelAll();
   await waitForNextUpdate();
 
-  expect(first.isCancelled).toBe(true);
-  expect(second.isCancelled).toBe(true);
+  expect(first.current.isCancelled).toBe(true);
+  expect(second.current.isCancelled).toBe(true);
 });
 
 test("exposing whether any instance is running", async () => {

--- a/src/__tests__/cancel-child-tasks.tsx
+++ b/src/__tests__/cancel-child-tasks.tsx
@@ -44,5 +44,5 @@ test("cancelling an outer task cancels an inner task", async () => {
   expect(beforeCancel).toBeCalled();
   expect(afterCancel).not.toBeCalled();
 
-  expect(outerInstance.isCancelled).toBe(true);
+  expect(outerInstance.current.isCancelled).toBe(true);
 });

--- a/src/__tests__/cancel-on-unmount.tsx
+++ b/src/__tests__/cancel-on-unmount.tsx
@@ -34,7 +34,7 @@ test("it cancels the task when the component is unmounted", async () => {
 
   unmount();
 
-  expect(lastInstance.isCancelled).toBe(true);
+  expect(lastInstance.current.isCancelled).toBe(true);
   expect(console.error).toBeCalledTimes(0); // eslint-disable-line no-console
 });
 

--- a/src/__tests__/handing-errors.tsx
+++ b/src/__tests__/handing-errors.tsx
@@ -36,12 +36,12 @@ test("it can handle an error thrown immediately in a task", async () => {
   await def;
 
   // Check task state
-  expect(taskInstance.isComplete).toBe(true);
-  expect(taskInstance.isRunning).toBe(false);
-  expect(taskInstance.isCancelled).toBe(false);
+  expect(taskInstance.current.isComplete).toBe(true);
+  expect(taskInstance.current.isRunning).toBe(false);
+  expect(taskInstance.current.isCancelled).toBe(false);
 
   // Check access to error object
-  expect(taskInstance.error).toBe(error);
+  expect(taskInstance.current.error).toBe(error);
 
   // Check `perform` surfacing the error
   expect(handleError).toBeCalledWith(error);
@@ -70,12 +70,12 @@ test("it can handle an error thrown later in a task", async () => {
   await def;
 
   // Check task state
-  expect(taskInstance.isComplete).toBe(true);
-  expect(taskInstance.isRunning).toBe(false);
-  expect(taskInstance.isCancelled).toBe(false);
+  expect(taskInstance.current.isComplete).toBe(true);
+  expect(taskInstance.current.isRunning).toBe(false);
+  expect(taskInstance.current.isCancelled).toBe(false);
 
   // Check access to error object
-  expect(taskInstance.error).toBe(error);
+  expect(taskInstance.current.error).toBe(error);
 
   // Check `perform` surfacing the error
   expect(handleError).toBeCalledWith(error);
@@ -100,6 +100,6 @@ test("it does not report an errored task as the last successful task", async () 
 
   await def;
 
-  expect(instance.error).not.toBeUndefined();
+  expect(instance.current.error).not.toBeUndefined();
   expect(stateFor(result).lastSucessful).toBe(undefined);
 });

--- a/src/__tests__/keep/first.tsx
+++ b/src/__tests__/keep/first.tsx
@@ -36,8 +36,8 @@ test("it prevents simultaneous async work", async () => {
 
   await waitForNextUpdate();
 
-  expect(first.isCancelled).not.toBe(true);
-  expect(second.isCancelled).toBe(true);
+  expect(first.current.isCancelled).toBe(false);
+  expect(second.current.isCancelled).toBe(true);
 
   expect(done).toBeCalledTimes(1);
   expect(stateFor(result).performCount).toBe(2);

--- a/src/__tests__/keep/last.tsx
+++ b/src/__tests__/keep/last.tsx
@@ -35,8 +35,8 @@ test("it prevents simultaneous async work", async () => {
     second = perform(result);
   });
 
-  expect(first.isCancelled).toBe(true);
-  expect(second.isCancelled).not.toBe(true);
+  expect(first.current.isCancelled).toBe(true);
+  expect(second.current.isCancelled).toBe(false);
 
   expect(stateFor(result).performCount).toBe(2);
 });

--- a/src/perform.ts
+++ b/src/perform.ts
@@ -19,7 +19,7 @@ export default async function perform<F extends AnyFunction>(
     while (!isFinished) {
       // Is the task has been cancelled, we can stop consuming from the
       // generator
-      if (task.isCancelled) {
+      if (task.current.isCancelled) {
         break;
       }
 


### PR DESCRIPTION
Inspired by React Refs and how they can be used to model mutable state
within React, I have decided that it might be easier to organize the
current state of a task in the same way, as it too can change over time.

This change allows a `TaskInstance` to be returned immediately after
performing it, but still allows for handling a change in state the same
way that one would handle any other change to a Ref.

Now, properties about the state of a task will be accessed off of
`TaskInstance.current`.

The `.lastSuccessful` property was updated to be an instance of `TaskState`,
since once a task has completed, the ability to await the result or cancel
the task is irrelevant.