### PR TITLE
Use reducer for internal state

### DIFF
--- a/src/__tests__/all-task-state.tsx
+++ b/src/__tests__/all-task-state.tsx
@@ -15,7 +15,7 @@ function stateFor(result) {
 test("allows cancelling all task instances", async () => {
   let first, second;
 
-  const { result, waitForNextUpdate } = renderHook(() =>
+  const { result } = renderHook(() =>
     useTask(
       function*() {
         yield timeout(0);
@@ -36,7 +36,6 @@ test("allows cancelling all task instances", async () => {
   expect(second.current.isCancelled).toBe(false);
 
   stateFor(result).cancelAll();
-  await waitForNextUpdate();
 
   expect(first.current.isCancelled).toBe(true);
   expect(second.current.isCancelled).toBe(true);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -28,8 +28,8 @@ class TaskInstance<Func extends AnyFunction, R = Result<Func>>
   [Symbol.toStringTag] = "TaskInstance";
 
   current: TaskInstanceState<R> = {
+    isRunning: true,
     isCancelled: false,
-    isRunning: false,
     isComplete: false
   };
 
@@ -72,10 +72,6 @@ class TaskInstance<Func extends AnyFunction, R = Result<Func>>
         throw e;
       }
     });
-  }
-
-  begin() {
-    this.updatePublicState({ isRunning: true });
   }
 
   resolve(result: R) {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -2,6 +2,7 @@ import React from "react";
 
 import Deferred from "./deferred";
 import CancellationError, { isCancellationError } from "./cancellation-error";
+import { Action } from "./state";
 
 export type AnyFunction = (...args: any[]) => any;
 type Generator = (...args: any[]) => IterableIterator<any>;
@@ -20,28 +21,29 @@ export interface TaskInstanceState<T> {
   error?: any;
 }
 
-class TaskInstance<Func extends AnyFunction, R = Result<Func>>
-  extends Deferred<R>
-  implements React.RefObject<TaskInstanceState<R>> {
+class TaskInstance<Func extends AnyFunction> extends Deferred<Result<Func>>
+  implements React.RefObject<TaskInstanceState<Result<Func>>> {
   fn: Func;
 
   [Symbol.toStringTag] = "TaskInstance";
 
-  current: TaskInstanceState<R> = {
+  current: TaskInstanceState<Result<Func>> = {
     isRunning: true,
     isCancelled: false,
     isComplete: false
   };
 
-  private notifyStateChange: () => void;
+  private dispatch: (value: Action<Func>) => void;
   private parentInstance?: TaskInstance<any>;
   private onCancelCallbacks: Array<AnyFunction> = [];
 
-  constructor(fn: Func, updateTaskState) {
+  constructor(fn: Func, dispatch: (value: Action<Func>) => void) {
     super();
 
     this.fn = fn;
-    this.notifyStateChange = updateTaskState;
+    this.dispatch = dispatch;
+
+    dispatch({ type: "BEGIN", instance: this });
   }
 
   /**
@@ -74,12 +76,8 @@ class TaskInstance<Func extends AnyFunction, R = Result<Func>>
     });
   }
 
-  resolve(result: R) {
-    this.updatePublicState({
-      isRunning: false,
-      isComplete: true,
-      result
-    });
+  resolve(result: Result<Func>) {
+    this.dispatch({ type: "COMPLETE", instance: this, result });
 
     if (this.subscribed) {
       super.resolve(result);
@@ -87,11 +85,11 @@ class TaskInstance<Func extends AnyFunction, R = Result<Func>>
   }
 
   reject(reason: any) {
-    this.updatePublicState({
-      isRunning: false,
-      isComplete: true,
-      error: reason
-    });
+    if (isCancellationError(reason)) {
+      this.dispatch({ type: "CANCEL", instance: this, error: reason });
+    } else {
+      this.dispatch({ type: "ERROR", instance: this, error: reason });
+    }
 
     if (this.subscribed) {
       super.reject(reason);
@@ -103,18 +101,11 @@ class TaskInstance<Func extends AnyFunction, R = Result<Func>>
       return;
     }
 
-    this.current.isCancelled = true;
-    this.reject(error);
-
     for (const callback of this.onCancelCallbacks) {
       callback(error);
     }
-  }
 
-  private updatePublicState(props) {
-    Object.assign(this.current, props);
-
-    this.notifyStateChange();
+    this.reject(error);
   }
 }
 

--- a/src/perform.ts
+++ b/src/perform.ts
@@ -5,8 +5,6 @@ export default async function perform<F extends AnyFunction>(
   task: TaskInstance<F>,
   args: Parameters<F>
 ) {
-  task.begin();
-
   await timeout(0);
 
   let result = task.fn(...args);

--- a/src/perform.ts
+++ b/src/perform.ts
@@ -5,6 +5,8 @@ export default async function perform<F extends AnyFunction>(
   task: TaskInstance<F>,
   args: Parameters<F>
 ) {
+  // Required to allow a user to catch an error even if it is
+  // thrown synchronously within the task
   await timeout(0);
 
   let result = task.fn(...args);
@@ -18,7 +20,7 @@ export default async function perform<F extends AnyFunction>(
       // Is the task has been cancelled, we can stop consuming from the
       // generator
       if (task.current.isCancelled) {
-        break;
+        return;
       }
 
       // Advance the generator with the last resolved value, so that

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,117 @@
+import { Reducer } from "react";
+import { KeepValue } from "./index";
+import TaskInstance, {
+  AnyFunction,
+  TaskInstanceState,
+  Result
+} from "./instance";
+import CancellationError from "./cancellation-error";
+
+export type InternalTaskState<F extends AnyFunction> = {
+  keep: KeepValue;
+  instances: TaskInstance<F>[];
+  lastSuccessful?: TaskInstance<F>;
+};
+
+interface BaseAction<F extends AnyFunction> {
+  type: string;
+  instance: TaskInstance<F>;
+}
+
+interface Begin<F extends AnyFunction> extends BaseAction<F> {
+  type: "BEGIN";
+}
+
+interface Complete<F extends AnyFunction> extends BaseAction<F> {
+  type: "COMPLETE";
+  result: Result<F>;
+}
+
+interface Error<F extends AnyFunction> extends BaseAction<F> {
+  type: "ERROR";
+  error: any;
+}
+
+interface Cancel<F extends AnyFunction> extends BaseAction<F> {
+  type: "CANCEL";
+  error: CancellationError;
+}
+
+export type Action<F extends AnyFunction> =
+  | Begin<F>
+  | Complete<F>
+  | Error<F>
+  | Cancel<F>;
+
+export type TaskStateReducer<F extends AnyFunction> = Reducer<
+  InternalTaskState<F>,
+  Action<F>
+>;
+
+function updateStateForInstance<F extends AnyFunction>(
+  instances: TaskInstance<F>[],
+  instanceToUpdate: TaskInstance<F>,
+  callback: () => TaskInstanceState<Result<F>>
+): TaskInstance<F>[] {
+  return instances.map(instance => {
+    if (instance === instanceToUpdate) {
+      instance.current = callback();
+    }
+
+    return instance;
+  });
+}
+
+const reducer = (state, action: Action<any>) => {
+  switch (action.type) {
+    case "BEGIN":
+      return { ...state, instances: [...state.instances, action.instance] };
+    case "COMPLETE":
+      return {
+        ...state,
+        instances: updateStateForInstance(
+          state.instances,
+          action.instance,
+          () => ({
+            isComplete: true,
+            isRunning: false,
+            isCancelled: false,
+            result: action.result
+          })
+        ),
+        lastSuccessful: action.instance
+      };
+    case "ERROR":
+      return {
+        ...state,
+        instances: updateStateForInstance(
+          state.instances,
+          action.instance,
+          () => ({
+            isComplete: true,
+            isRunning: false,
+            isCancelled: false,
+            error: action.error
+          })
+        )
+      };
+    case "CANCEL":
+      return {
+        ...state,
+        instances: updateStateForInstance(
+          state.instances,
+          action.instance,
+          () => ({
+            isComplete: true,
+            isRunning: false,
+            isCancelled: true,
+            error: action.error
+          })
+        )
+      };
+    default:
+      throw new Error("Unexpected dispatch received");
+  }
+};
+
+export default reducer;


### PR DESCRIPTION
Using a reducer internally isn't much different than before, but makes it quite a bit easier to keep track of where changes to the `.current` object happen.

## Todo

- [ ] Verify that `cancelAll` does not trigger `N` re-renders of the hook (one for each task, since each cancellation would call `dispatch`)

***

Closes #15 