### PR TITLE
Async generators

### DIFF
--- a/__tests__/default-behavior.test.tsx
+++ b/__tests__/default-behavior.test.tsx
@@ -67,3 +67,28 @@ test("it can perform a generator function", async () => {
   expect(done).toBeCalled();
   expect(stateFor(result).isRunning).toBe(false);
 });
+
+test("it can perform an async generator function", async () => {
+  const done = jest.fn();
+
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTask(async function*() {
+      yield timeout(0);
+      done();
+    })
+  );
+
+  expect(stateFor(result).isRunning).toBe(false);
+  expect(stateFor(result).performCount).toBe(0);
+
+  act(() => {
+    perform(result);
+  });
+
+  expect(stateFor(result).isRunning).toBe(true);
+
+  await waitForNextUpdate();
+
+  expect(done).toBeCalled();
+  expect(stateFor(result).isRunning).toBe(false);
+});

--- a/src/perform.ts
+++ b/src/perform.ts
@@ -28,7 +28,7 @@ export default async function perform<F extends AnyFunction>(
       // a user can treat the `yield` like `async/await` and get the
       // last value out of it. We can also use this for nested tasks
       try {
-        const { value, done } = generator.next(lastResolvedValue);
+        const { value, done } = await generator.next(lastResolvedValue);
 
         if (value instanceof TaskInstance) {
           // Cancel the "child" when the "parent" is cancelled


### PR DESCRIPTION
I found myself wanting the ability to use async generators, mainly to be able to use `for await (let thing of things) {}` which as far as I'm aware don't have a simple generator equivalent.

This seems to be as simple as `await generator.next()`, but I'm curious if there are any side effects I might be missing. Without the `await`, `generator.next()` returns a promise which doesn't have a `done` property, to the task just hangs.